### PR TITLE
fix: fix round robin for API call

### DIFF
--- a/presto-main/src/main/java/io/prestosql/metadata/DynamicCatalogStore.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/DynamicCatalogStore.java
@@ -24,7 +24,6 @@ import io.airlift.http.client.jetty.JettyHttpClient;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
 import io.prestosql.connector.ConnectorManager;
-import io.prestosql.spi.PrestoException;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -51,7 +50,6 @@ import static io.airlift.discovery.client.ServiceAnnouncement.serviceAnnouncemen
 import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
 import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.json.JsonCodec.jsonCodec;
-import static io.prestosql.metadata.DynamicCatalogStoreErrorCode.DATA_CONNECTION_REQUEST_FAILED;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
@@ -107,7 +105,7 @@ public class DynamicCatalogStore
         this.dataConnectionApiKey = requireNonNull(dataConnectionApiKey, "dataConnectionApiKey is null.");
         this.dataConnectionCryptoKey = requireNonNull(dataConnectionCryptoKey, "dataConnectionCryptoKey is null");
         this.disabledCatalogs = ImmutableSet.copyOf(disabledCatalogs);
-        this.dataConnectionUrls = new DynamicCatalogStoreRoundRobin(requireNonNull(dataConnectionUrl, "dataConnectionUrl is null."));
+        this.dataConnectionUrls = DynamicCatalogStoreRoundRobin.getInstance(requireNonNull(dataConnectionUrl, "dataConnectionUrl is null."));
         this.scheduler = scheduler;
         this.httpClient = new JettyHttpClient();
         this.announcer = announcer;
@@ -143,11 +141,11 @@ public class DynamicCatalogStore
     /**
      * Get the name and id of the catalog     *
      * <p>
-     *     This method gets the name of the catalog received by the api
+     * This method gets the name of the catalog received by the api
      * </p>     *
-     * @param dataConnection  a object received by the api
-     * @return  a String as the name of the catalog
      *
+     * @param dataConnection a object received by the api
+     * @return a String as the name of the catalog
      * @see DataConnection
      */
     public static String getCatalogName(DataConnection dataConnection)
@@ -292,20 +290,21 @@ public class DynamicCatalogStore
     private List<DataConnection> getDataConnections(String dataConnectionEndpoint, String queryParameters)
     {
         DataConnectionResponse response = null;
-        try {
-            response = httpClient.execute(
-                    prepareGet().setUri(uriFor(dataConnectionUrls.getServer(), dataConnectionEndpoint + queryParameters))
-                            .setHeader(AUTHORIZATION, dataConnectionApiKey)
-                            .build(),
-                    createJsonResponseHandler(jsonCodec));
-        }
-        catch (Exception e) {
-            if (e.getCause() instanceof IOException) {
-                log.error("Unable to connect to API");
-                log.error(e.getMessage());
+        Integer poolSize = dataConnectionUrls.getPoolSize();
+        for (int i = 0; i < poolSize; i++) {
+            String apiServer = null;
+            try {
+                apiServer = dataConnectionUrls.getServer();
+                response = httpClient.execute(
+                        prepareGet().setUri(uriFor(apiServer, dataConnectionEndpoint + queryParameters))
+                                .setHeader(AUTHORIZATION, dataConnectionApiKey)
+                                .build(),
+                        createJsonResponseHandler(jsonCodec));
+                log.info(String.format("API server [%s] ok", apiServer));
             }
-            else {
-                throw new PrestoException(DATA_CONNECTION_REQUEST_FAILED, e);
+            catch (Exception e) {
+                log.error(String.format("Unable to connect to API server: %s", apiServer));
+                log.error(e.getMessage());
             }
         }
 

--- a/presto-main/src/main/java/io/prestosql/metadata/DynamicCatalogStore.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/DynamicCatalogStore.java
@@ -178,7 +178,7 @@ public class DynamicCatalogStore
     private void updateCatalogDelta()
             throws Exception
     {
-        log.info("updating catalogs");
+        log.debug("updating catalogs");
         List<DataConnection> delta = listCatalogDelta();
         if (delta.size() > 0) {
             for (DataConnection dataConnection : delta) {
@@ -300,10 +300,13 @@ public class DynamicCatalogStore
                                 .setHeader(AUTHORIZATION, dataConnectionApiKey)
                                 .build(),
                         createJsonResponseHandler(jsonCodec));
-                log.info(String.format("API server [%s] ok", apiServer));
+                log.debug(String.format("API server [%s] - ok - request %s", apiServer, (queryParameters.contains("delete") ? "delete delta" : "delta")));
+                log.debug(dataConnectionEndpoint + queryParameters);
+                break;
             }
             catch (Exception e) {
-                log.error(String.format("Unable to connect to API server: %s", apiServer));
+                log.error(String.format("API server [%s] - unable to connect - request %s", apiServer, (queryParameters.contains("delete") ? "delete delta" : "delta")));
+                log.error(dataConnectionEndpoint + queryParameters);
                 log.error(e.getMessage());
             }
         }

--- a/presto-main/src/main/java/io/prestosql/metadata/DynamicCatalogStoreRoundRobin.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/DynamicCatalogStoreRoundRobin.java
@@ -17,12 +17,17 @@ public class DynamicCatalogStoreRoundRobin
 {
     public static String[] ipSet;
 
-    public DynamicCatalogStoreRoundRobin(String ipSet)
+    private static DynamicCatalogStoreRoundRobin catalogStoreRoundRobin = null;
+
+    private DynamicCatalogStoreRoundRobin(String ipSet)
     {
         this.ipSet = ipSet.split(";");
+        this.poolSize = this.ipSet.length;
     }
 
     private static Integer position = 0;
+
+    private static Integer poolSize;
 
     public String getServer()
     {
@@ -36,5 +41,20 @@ public class DynamicCatalogStoreRoundRobin
             position++;
         }
         return target;
+    }
+
+    public Integer getPoolSize()
+    {
+        return poolSize;
+    }
+
+    public static DynamicCatalogStoreRoundRobin getInstance(String ipSet)
+    {
+        if (catalogStoreRoundRobin == null) {
+            return new DynamicCatalogStoreRoundRobin(ipSet);
+        }
+        else {
+            return catalogStoreRoundRobin;
+        }
     }
 }

--- a/presto-main/src/test/java/io/prestosql/metadata/TestDynamicCatalogStoreRoundRobin.java
+++ b/presto-main/src/test/java/io/prestosql/metadata/TestDynamicCatalogStoreRoundRobin.java
@@ -13,25 +13,17 @@
  */
 package io.prestosql.metadata;
 
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDynamicCatalogStoreRoundRobin
 {
-    private static String ipSet = "localhost;127.0.0.1;server3;server4";
-    private DynamicCatalogStoreRoundRobin rr;
-
-    @BeforeTest
-    public void setup()
-    {
-        rr = new DynamicCatalogStoreRoundRobin(ipSet);
-    }
-
     @Test
     public void shouldGetDataConnectionTypeString()
     {
+        String ipSet = "localhost;127.0.0.1;server3;server4";
+        DynamicCatalogStoreRoundRobin rr = DynamicCatalogStoreRoundRobin.getInstance(ipSet);
         assertThat(rr.getServer()).isEqualTo("localhost");
         assertThat(rr.getServer()).isEqualTo("127.0.0.1");
         assertThat(rr.getServer()).isEqualTo("server3");
@@ -40,5 +32,22 @@ public class TestDynamicCatalogStoreRoundRobin
         assertThat(rr.getServer()).isEqualTo("127.0.0.1");
         assertThat(rr.getServer()).isEqualTo("server3");
         assertThat(rr.getServer()).isEqualTo("server4");
+    }
+
+    @Test
+    public void shouldGetPoolSize()
+    {
+        String ipSet = "localhost;127.0.0.1;server3;server4";
+        DynamicCatalogStoreRoundRobin rr = DynamicCatalogStoreRoundRobin.getInstance(ipSet);
+        assertThat(rr.getPoolSize()).isEqualTo(4);
+    }
+
+    @Test
+    public void shouldGetInstanceWithOneServer()
+    {
+        String single = "localhost";
+        DynamicCatalogStoreRoundRobin roundRobin = DynamicCatalogStoreRoundRobin.getInstance(single);
+        assertThat(roundRobin.getServer()).isEqualTo("localhost");
+        assertThat(roundRobin.getPoolSize()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
The round robin functionality was not correctly working as Presto does 2 consecutive calls and the round robin would always call the first address to the first call, and the second address to the second call. The problem would not be seen there were a number of addresses differente then 2.